### PR TITLE
Userprofile feat

### DIFF
--- a/backend/afro-vintage-backend/cmd/main.go
+++ b/backend/afro-vintage-backend/cmd/main.go
@@ -99,7 +99,7 @@ func main() {
 	routes.RegisterSupplierRoutes(r, supplierCtrl, jwtSvc)
 	routes.RegisterWarehouseRoutes(r, warehouseCtrl, jwtSvc)
 	routes.RegisterResellerRoutes(r, supplierCtrl, jwtSvc)
-	routes.SetupUserRoutes(r, userUC) // Add user routes
+	routes.SetupUserRoutes(r, userUC, jwtSvc) // Add user routes
 
 	// Run server
 	r.Run(":8080")

--- a/backend/afro-vintage-backend/internal/domain/user/user.go
+++ b/backend/afro-vintage-backend/internal/domain/user/user.go
@@ -24,4 +24,5 @@ type User struct {
 	TrustTotalError float64   `bson:"trust_total_error"`
 	IsDeleted       bool      `bson:"is_deleted"`
 	IsBlacklisted   bool      `bson:"is_blacklisted"`
+	ImageURL        string    `bson:"image_url"` // URL to the user's profile image
 }

--- a/backend/afro-vintage-backend/internal/interface/controllers/user_controller.go
+++ b/backend/afro-vintage-backend/internal/interface/controllers/user_controller.go
@@ -7,12 +7,21 @@ import (
 	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/user"
 )
 
-type UserController struct {
-	userUC user.Usecase
+type UpdateProfileRequest struct {
+	Name     string `json:"name,omitempty"`
+	Username string `json:"username,omitempty"`
+	Email    string `json:"email,omitempty"`
+	ImageURL string `json:"image_url,omitempty"`
 }
 
-func NewUserController(userUC user.Usecase) *UserController {
-	return &UserController{userUC: userUC}
+type UserController struct {
+	userUsecase user.Usecase
+}
+
+func NewUserController(userUsecase user.Usecase) *UserController {
+	return &UserController{
+		userUsecase: userUsecase,
+	}
 }
 
 // GetUserByID handles GET /api/users/:id
@@ -23,7 +32,7 @@ func (c *UserController) GetUserByID(ctx *gin.Context) {
 		return
 	}
 
-	user, err := c.userUC.GetByID(ctx, userID)
+	user, err := c.userUsecase.GetByID(ctx, userID)
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -36,4 +45,93 @@ func (c *UserController) GetUserByID(ctx *gin.Context) {
 		"email":    user.Email,
 		"role":     user.Role,
 	})
+}
+
+func (c *UserController) UpdateProfile(ctx *gin.Context) {
+	userID, exists := ctx.Get("userID")
+	if !exists {
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	userIDStr, ok := userID.(string)
+	if !ok {
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "invalid user ID"})
+		return
+	}
+
+	var req UpdateProfileRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+		return
+	}
+
+	// Create update map with only non-empty fields
+	updates := make(map[string]interface{})
+	if req.Name != "" {
+		updates["name"] = req.Name
+	}
+	if req.Username != "" {
+		updates["username"] = req.Username
+	}
+	if req.Email != "" {
+		updates["email"] = req.Email
+	}
+	if req.ImageURL != "" {
+		updates["image_url"] = req.ImageURL
+	}
+
+	if len(updates) == 0 {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "no fields to update"})
+		return
+	}
+
+	// Get current user to check username and email
+	currentUser, err := c.userUsecase.GetByID(ctx, userIDStr)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get user information"})
+		return
+	}
+
+	// Check if username is already taken if it's being updated
+	if req.Username != "" && req.Username != currentUser.Username {
+		// Get all users to check for duplicate username
+		users, err := c.userUsecase.ListByRole(ctx, user.Role(currentUser.Role))
+		if err != nil {
+			ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to check username availability"})
+			return
+		}
+
+		for _, u := range users {
+			if u.Username == req.Username && u.ID != userIDStr {
+				ctx.JSON(http.StatusConflict, gin.H{"error": "username already taken"})
+				return
+			}
+		}
+	}
+
+	// Check if email is already taken if it's being updated
+	if req.Email != "" && req.Email != currentUser.Email {
+		// Get all users to check for duplicate email
+		users, err := c.userUsecase.ListByRole(ctx, user.Role(currentUser.Role))
+		if err != nil {
+			ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to check email availability"})
+			return
+		}
+
+		for _, u := range users {
+			if u.Email == req.Email && u.ID != userIDStr {
+				ctx.JSON(http.StatusConflict, gin.H{"error": "email already taken"})
+				return
+			}
+		}
+	}
+
+	err = c.userUsecase.Update(ctx, userIDStr, updates)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update profile"})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{"message": "profile updated successfully"})
 } 

--- a/backend/afro-vintage-backend/internal/interface/routes/user_route.go
+++ b/backend/afro-vintage-backend/internal/interface/routes/user_route.go
@@ -3,15 +3,23 @@ package routes
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/user"
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/auth"
 	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/interface/controllers"
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/interface/middlewares"
 )
 
-func SetupUserRoutes(router *gin.Engine, userUC user.Usecase) {
-	userController := controllers.NewUserController(userUC)
+func SetupUserRoutes(router *gin.Engine, userUsecase user.Usecase, jwtSvc auth.JWTService) {
+	userController := controllers.NewUserController(userUsecase)
 	
 	// Public user routes
 	userRoutes := router.Group("/api/users")
 	{
 		userRoutes.GET("/:id", userController.GetUserByID)
+	}
+
+	userGroup := router.Group("/api/users")
+	{
+		userGroup.Use(middlewares.AuthMiddleware(jwtSvc))
+		userGroup.PUT("/profile", userController.UpdateProfile)
 	}
 } 

--- a/backend/afro-vintage-backend/internal/usecase/order/OrderUsecase.go
+++ b/backend/afro-vintage-backend/internal/usecase/order/OrderUsecase.go
@@ -180,7 +180,7 @@ func (uc *orderUseCaseImpl) GetDashboardMetrics(ctx context.Context, supplierID 
 }
 
 func (uc *orderUseCaseImpl) GetResellerMetrics(ctx context.Context, resellerID string) (*order.ResellerMetrics, error) {
-	fmt.Printf("🔍 Starting GetResellerMetrics for reseller: %s\n", resellerID)
+	fmt.Printf("\n🔍 Starting GetResellerMetrics for reseller: %s\n", resellerID)
 
 	// Get purchased bundles
 	bundles, err := uc.bundleRepo.ListPurchasedByReseller(ctx, resellerID)
@@ -197,6 +197,11 @@ func (uc *orderUseCaseImpl) GetResellerMetrics(ctx context.Context, resellerID s
 		return nil, err
 	}
 	fmt.Printf("👤 Reseller found: %s\n", reseller.Username)
+	fmt.Printf("📊 Reseller Trust Data:\n")
+	fmt.Printf("  - Trust Score: %d\n", reseller.TrustScore)
+	fmt.Printf("  - Trust Rated Count: %d\n", reseller.TrustRatedCount)
+	fmt.Printf("  - Trust Total Error: %f\n", reseller.TrustTotalError)
+	fmt.Printf("  - Is Blacklisted: %v\n", reseller.IsBlacklisted)
 
 	// Get sold products directly from product collection
 	soldProducts, err := uc.prodRepo.GetSoldProductsByReseller(ctx, resellerID)
@@ -224,7 +229,13 @@ func (uc *orderUseCaseImpl) GetResellerMetrics(ctx context.Context, resellerID s
 		BoughtBundles:      bundles,
 	}
 
-	fmt.Printf("✅ Final metrics: %+v\n", metrics)
+	fmt.Printf("📊 Final Metrics:\n")
+	fmt.Printf("  - Total Bought Bundles: %d\n", metrics.TotalBoughtBundles)
+	fmt.Printf("  - Total Items Sold: %d\n", metrics.TotalItemsSold)
+	fmt.Printf("  - Rating (Trust Score): %d\n", metrics.Rating)
+	fmt.Printf("  - Best Selling: %.2f\n", metrics.BestSelling)
+	fmt.Printf("✅ GetResellerMetrics completed\n\n")
+
 	return metrics, nil
 }
 


### PR DESCRIPTION


These changes 
Adds a PUT /api/users/profile endpoint to allow users to update their name, username, email, and profile image.

Adds validation for duplicate usernames, duplicate emails, and empty update requests.

Secures the profile update endpoint with authentication and proper error handling.

Improves trust score calculation:

Applies a sliding window with weighted average (30% historical, 70% recent performance).

Ensures recent good performance can boost supplier trust scores, while still maintaining accountability.

 How to Test
Send a PUT /api/users/profile request with updated fields.

Verify that trust scores adjust correctly after submitting new ratings, reflecting recent improvements.